### PR TITLE
Update node version to 16.10 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.3.0-alpine3.10
+FROM node:16.10.0-alpine3.14
 
 LABEL maintainer="chris.adadev.org"
 


### PR DESCRIPTION
This is the same fix Mark applied to JS Adagrams. I pulled down the existing docker image, confirmed that we encounter the failure Learn is reporting, got the new docker image, and confirmed that `yarn install` works and that tests can run.