### PR TITLE
Fix test formatting and data.

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,53 +1,53 @@
-import React from 'react'
-import App from './App'
-import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react';
+import App from './App';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 describe('Wave 03: clicking like button and rendering App', () => {
   test('that the correct number of likes is printed at the top', () => {
     // Arrange
-    const { container } = render(<App />)
-    let buttons = container.querySelectorAll('button.like')
+    const { container } = render(<App />);
+    let buttons = container.querySelectorAll('button.like');
 
     // Act
-    fireEvent.click(buttons[0])
-    fireEvent.click(buttons[1])
-    fireEvent.click(buttons[10])
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    fireEvent.click(buttons[10]);
 
     // Assert
-    const countScreen = screen.getByText(/3 ❤️s/)
-    expect(countScreen).not.toBeNull()
-  })
+    const countScreen = screen.getByText(/3 ❤️s/);
+    expect(countScreen).not.toBeNull();
+  });
 
   test('clicking button toggles heart and does not affect other buttons', () => {
     // Arrange
-    const { container } = render(<App />)
-    const buttons = container.querySelectorAll('button.like')
-    const firstButton = buttons[0]
-    const lastButton = buttons[buttons.length - 1]
+    const { container } = render(<App />);
+    const buttons = container.querySelectorAll('button.like');
+    const firstButton = buttons[0];
+    const lastButton = buttons[buttons.length - 1];
 
     // Act-Assert
 
     // click the first button
-    fireEvent.click(firstButton)
-    expect(firstButton.innerHTML).toEqual('❤️')
+    fireEvent.click(firstButton);
+    expect(firstButton.innerHTML).toEqual('❤️');
 
     // check that all other buttons haven't changed
     for (let i = 1; i < buttons.length; i++) {
-      expect(buttons[i].innerHTML).toEqual('🤍')
+      expect(buttons[i].innerHTML).toEqual('🤍');
     }
 
     // click the first button a few more times
-    fireEvent.click(firstButton)
-    expect(firstButton.innerHTML).toEqual('🤍')
-    fireEvent.click(firstButton)
-    expect(firstButton.innerHTML).toEqual('❤️')
-    fireEvent.click(firstButton)
-    expect(firstButton.innerHTML).toEqual('🤍')
+    fireEvent.click(firstButton);
+    expect(firstButton.innerHTML).toEqual('🤍');
+    fireEvent.click(firstButton);
+    expect(firstButton.innerHTML).toEqual('❤️');
+    fireEvent.click(firstButton);
+    expect(firstButton.innerHTML).toEqual('🤍');
 
     // click the last button a couple times
-    fireEvent.click(lastButton)
-    expect(lastButton.innerHTML).toEqual('❤️')
-    fireEvent.click(lastButton)
-    expect(lastButton.innerHTML).toEqual('🤍')
-  })
-})
+    fireEvent.click(lastButton);
+    expect(lastButton.innerHTML).toEqual('❤️');
+    fireEvent.click(lastButton);
+    expect(lastButton.innerHTML).toEqual('🤍');
+  });
+});

--- a/src/components/ChatEntry.test.js
+++ b/src/components/ChatEntry.test.js
@@ -1,9 +1,9 @@
-import React from "react";
-import "@testing-library/jest-dom/extend-expect";
-import ChatEntry from "./ChatEntry";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import ChatEntry from './ChatEntry';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-describe("Wave 01: ChatEntry", () => {
+describe('Wave 01: ChatEntry', () => {
   beforeEach(() => {
     render(
       <ChatEntry
@@ -14,15 +14,15 @@ describe("Wave 01: ChatEntry", () => {
     );
   });
 
-  test("renders without crashing and shows the sender", () => {
+  test('renders without crashing and shows the sender', () => {
     expect(screen.getByText(/Joe Biden/)).toBeInTheDocument();
   });
 
-  test("that it will display the body", () => {
+  test('that it will display the body', () => {
     expect(screen.getByText(/Get out by 8am/)).toBeInTheDocument();
   });
 
-  test("that it will display the time", () => {
+  test('that it will display the time', () => {
     expect(screen.getByText(/\d+ years ago/)).toBeInTheDocument();
   });
 });

--- a/src/components/ChatEntry.test.js
+++ b/src/components/ChatEntry.test.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import ChatEntry from './ChatEntry';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 describe('Wave 01: ChatEntry', () => {
   beforeEach(() => {
     render(
       <ChatEntry
+        id={7}
         sender="Joe Biden"
         body="Get out by 8am.  I'll count the silverware"
         timeStamp="2018-05-18T22:12:03Z"
+        liked={false}
       />
     );
   });

--- a/src/components/ChatLog.test.js
+++ b/src/components/ChatLog.test.js
@@ -1,49 +1,49 @@
-import React from "react";
-import "@testing-library/jest-dom/extend-expect";
-import ChatLog from "./ChatLog";
-import { render, screen } from "@testing-library/react";
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import ChatLog from './ChatLog';
+import { render, screen } from '@testing-library/react';
 
 const LOG = [
   {
-    sender: "Vladimir",
-    body: "why are you arguing with me",
-    timeStamp: "2018-05-29T22:49:06+00:00",
+    sender: 'Vladimir',
+    body: 'why are you arguing with me',
+    timeStamp: '2018-05-29T22:49:06+00:00',
   },
   {
-    sender: "Estragon",
-    body: "Because you are wrong.",
-    timeStamp: "2018-05-29T22:49:33+00:00",
+    sender: 'Estragon',
+    body: 'Because you are wrong.',
+    timeStamp: '2018-05-29T22:49:33+00:00',
   },
   {
-    sender: "Vladimir",
-    body: "because I am what",
-    timeStamp: "2018-05-29T22:50:22+00:00",
+    sender: 'Vladimir',
+    body: 'because I am what',
+    timeStamp: '2018-05-29T22:50:22+00:00',
   },
   {
-    sender: "Estragon",
-    body: "A robot.",
-    timeStamp: "2018-05-29T22:52:21+00:00",
+    sender: 'Estragon',
+    body: 'A robot.',
+    timeStamp: '2018-05-29T22:52:21+00:00',
   },
   {
-    sender: "Vladimir",
-    body: "Notabot",
-    timeStamp: "2019-07-23T22:52:21+00:00",
+    sender: 'Vladimir',
+    body: 'Notabot',
+    timeStamp: '2019-07-23T22:52:21+00:00',
   },
 ];
 
-describe("Wave 02: ChatLog", () => {
+describe('Wave 02: ChatLog', () => {
   beforeEach(() => {
     render(<ChatLog entries={LOG} />);
   });
 
-  test("renders without crashing and shows all the names", () => {
+  test('renders without crashing and shows all the names', () => {
     [
       {
-        name: "Vladimir",
+        name: 'Vladimir',
         numChats: 3,
       },
       {
-        name: "Estragon",
+        name: 'Estragon',
         numChats: 2,
       },
     ].forEach((person) => {
@@ -56,7 +56,7 @@ describe("Wave 02: ChatLog", () => {
     });
   });
 
-  test("renders an empty list without crashing", () => {
+  test('renders an empty list without crashing', () => {
     const element = render(<ChatLog entries={[]} />);
     expect(element).not.toBeNull();
   });

--- a/src/components/ChatLog.test.js
+++ b/src/components/ChatLog.test.js
@@ -5,29 +5,39 @@ import { render, screen } from '@testing-library/react';
 
 const LOG = [
   {
+    id: 1,
     sender: 'Vladimir',
     body: 'why are you arguing with me',
     timeStamp: '2018-05-29T22:49:06+00:00',
+    liked: false,
   },
   {
+    id: 2,
     sender: 'Estragon',
     body: 'Because you are wrong.',
     timeStamp: '2018-05-29T22:49:33+00:00',
+    liked: false,
   },
   {
+    id: 3,
     sender: 'Vladimir',
     body: 'because I am what',
     timeStamp: '2018-05-29T22:50:22+00:00',
+    liked: false,
   },
   {
+    id: 4,
     sender: 'Estragon',
     body: 'A robot.',
     timeStamp: '2018-05-29T22:52:21+00:00',
+    liked: false,
   },
   {
+    id: 5,
     sender: 'Vladimir',
     body: 'Notabot',
     timeStamp: '2019-07-23T22:52:21+00:00',
+    liked: false,
   },
 ];
 


### PR DESCRIPTION
- Previously, the test data did not match the format of what was in the `messages.json`. This caused all sorts of prop types and keys warnings that confused students made the Learn output often indecipherable. This PR adds the missing data.

- Previously the test files did not consistently use semicolons and used double quotes. This PR brings the test file formatting in alignment with the style we ask our students to use.

- Removed unused imports.