### PR TITLE
Add timestamp explanation

### DIFF
--- a/project-docs/setup.md
+++ b/project-docs/setup.md
@@ -18,8 +18,15 @@ Once you've identified which data will be used by which components, consider the
 
 Finally, after analyzing the provided data and designing a set of components and their relationships to the data, you should write down your proposed design.
 
-
 Consider discussing your design with a classmate. Is their design different from yours? If so, discuss the reasoning for each of yours designs and determine any possible pros/cons for both approaches.
+
+### Hint: The `TimeStamp` Component
+
+The `TimeStamp` component has already been implemented for you. The `ChatEntry` component should use an instance of the `TimeStamp` component.
+
+The `TimeStamp` component expects one `prop`: `time`.
+
+If this component receives `time` through `props` correctly, it will render the time in a nice format!
 
 ## Setup
 

--- a/project-docs/wave-01.md
+++ b/project-docs/wave-01.md
@@ -6,7 +6,7 @@ Update the `ChatEntry` and `App` components to display a single chat message bub
 
 A good way to test this code as you write it would be to take the first chat message from the JSON data file and use it as the data for the `ChatEntry` component.
 
-`ChatEntry` should have props which match the elements from each chat message in the JSON data file: `sender`, `body`,  and `timeStamp`. Note: We do not need to include the `id` and `liked` fields for Wave 01.
+`ChatEntry` should have props which match the elements from each chat message in the JSON data file: `sender`, `body`,  and `timeStamp`. Note: We do not need to include the `id` and `liked` fields for Wave 01. Additionally, don't forget about the [hint](./setup.md#hint-the-timestamp-component) from the setup docs!
 
 ## Styling
 


### PR DESCRIPTION
**Summary of Changes**
- Add modified explanation of `TimeStamp` component included in [Timeline Problem Set](https://learn-2.galvanize.com/cohorts/2330/blocks/1449/content_files/props/problem-set-timeline.md) to React Chatlog instructions
- Addresses tickets:
    - [Chatlog Readme - Wave 01  - Talk about TimeStamp](https://app.asana.com/0/1201700438643002/1202459702278907/f) 
    - part of [`react-chatlog` and `js-adagrams`](https://app.asana.com/0/1201700438643002/1203665810642885/f)

**Notes**
- Becca suggested adding the `TimeStamp` explanation to Wave 01 instructions, but I placed it as that is where they are first asked to talk about how the data and components will be grouped. Open to other opinions however! 